### PR TITLE
fixes utf-8 non-ascii symbols error in goog.module

### DIFF
--- a/closure/bin/build/closurebuilder.py
+++ b/closure/bin/build/closurebuilder.py
@@ -186,7 +186,7 @@ class _PathSource(source.Source):
 
 
 def _WrapGoogModuleSource(src):
-  return ('goog.loadModule(function(exports) {{'
+  return (u'goog.loadModule(function(exports) {{'
           '"use strict";'
           '{0}'
           '\n'  # terminate any trailing single line comment.


### PR DESCRIPTION
fixes utf-8 non-ascii symbols error in goog.module while building js

If goog.module  `src` contains non-ascii symbols, e.g. russian comment, russian literal, then builder fails with error
```
/home/rshamyan/develop/changers/collectivoo/node_modules/google-closure-library/closure/bin/build/closurebuilder.py: Scanning paths...
/home/rshamyan/develop/changers/collectivoo/node_modules/google-closure-library/closure/bin/build/closurebuilder.py: 2137 sources scanned.
/home/rshamyan/develop/changers/collectivoo/node_modules/google-closure-library/closure/bin/build/closurebuilder.py: Building dependency tree..
Traceback (most recent call last):
  File "/home/rshamyan/develop/changers/collectivoo/node_modules/google-closure-library/closure/bin/build/closurebuilder.py", line 293, in <module>
    main()
  File "/home/rshamyan/develop/changers/collectivoo/node_modules/google-closure-library/closure/bin/build/closurebuilder.py", line 258, in main
    src = _WrapGoogModuleSource(src)
  File "/home/rshamyan/develop/changers/collectivoo/node_modules/google-closure-library/closure/bin/build/closurebuilder.py", line 194, in _WrapGoogModuleSource
    '}});\n').format(src)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 373-379: ordinal not in range(128)
```

This pull request fixes that problem